### PR TITLE
feat: add http status code enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,31 +33,31 @@ open an issue.
 With GET request
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 APP = API(name="app")
 
 @APP.route('/test/tests/<id>', methods=['GET'], cors=True)
 def print_id(id):
-    return ('OK', 'plain/text', id)
+    return (StatusCode.OK, 'plain/text', id)
 ```
 
 With POST request
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 APP = API(name="app")
 
 @APP.route('/test/tests/<id>', methods=['POST'], cors=True)
 def print_id(id, body):
-    return ('OK', 'plain/text', id)
+    return (StatusCode.OK, 'plain/text', id)
 ```
 
 ## Binary body
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 APP = API(name="app")
 
@@ -89,11 +89,11 @@ example:
 ```python
 @APP.get("/app/<regex([a-z]+):regularuser>")
 def print_user(regularuser):
-    return ('OK', 'plain/text', f"regular {regularuser}")
+    return (StatusCode.OK, 'plain/text', f"regular {regularuser}")
 
 @APP.get("/app/<regex([A-Z]+):capitaluser>")
 def print_user(capitaluser):
-    return ('OK', 'plain/text', f"CAPITAL {capitaluser}")
+    return (StatusCode.OK, 'plain/text', f"CAPITAL {capitaluser}")
 ```
 
 #### Warning
@@ -103,11 +103,11 @@ when using **regex()** you must use different variable names or the route might 
 ```python
 @APP.get("/app/<regex([a-z]+):user>")
 def print_user(user):
-    return ('OK', 'plain/text', f"regular {user}")
+    return (StatusCode.OK, 'plain/text', f"regular {user}")
 
 @APP.get("/app/<regex([A-Z]+):user>")
 def print_user(user):
-    return ('OK', 'plain/text', f"CAPITAL {user}")
+    return (StatusCode.OK, 'plain/text', f"CAPITAL {user}")
 ```
 This app will work but the documentation will only show the second route because in `openapi.json`, route names will be `/app/{user}` for both routes.
 
@@ -129,12 +129,12 @@ This app will work but the documentation will only show the second route because
 Add a Cache Control header with a Time to Live (TTL) in seconds.
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 APP = API(app_name="app")
 
 @APP.get('/test/tests/<id>', cors=True, cache_control="public,max-age=3600")
 def print_id(id):
-   return ('OK', 'plain/text', id)
+   return (StatusCode.OK, 'plain/text', id)
 ```
 
 Note: If function returns other then "OK", Cache-Control will be set to `no-cache`
@@ -144,14 +144,14 @@ Note: If function returns other then "OK", Cache-Control will be set to `no-cach
 When working with binary on API-Gateway we must return a base64 encoded string
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 APP = API(name="app")
 
 @APP.get('/test/tests/<filename>.jpg', cors=True, binary_b64encode=True)
 def print_id(filename):
     with open(f"{filename}.jpg", "rb") as f:
-        return ('OK', 'image/jpeg', f.read())
+        return (StatusCode.OK, 'image/jpeg', f.read())
 ```
 
 ## Compression
@@ -159,7 +159,7 @@ def print_id(filename):
 Enable compression if "Accept-Encoding" if found in headers.
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 APP = API(name="app")
 
@@ -171,7 +171,7 @@ APP = API(name="app")
 )
 def print_id(filename):
     with open(f"{filename}.jpg", "rb") as f:
-       return ('OK', 'image/jpeg', f.read())
+       return (StatusCode.OK, 'image/jpeg', f.read())
 ```
 
 ## Simple Auth token
@@ -183,13 +183,13 @@ Lambda-proxy provide a simple token validation system.
    http://myurl/test/tests/myid?access_token=blabla)
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 APP = API(name="app")
 
 @APP.get('/test/tests/<id>', cors=True, token=True)
 def print_id(id):
-    return ('OK', 'plain/text', id)
+    return (StatusCode.OK, 'plain/text', id)
 ```
 
 ## URL schema and request parameters
@@ -197,13 +197,13 @@ def print_id(id):
 QueryString parameters are passed as function's options.
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 APP = API(name="app")
 
 @APP.get('/<id>', cors=True)
 def print_id(id, name=None):
-    return ('OK', 'plain/text', f"{id}{name}")
+    return (StatusCode.OK, 'plain/text', f"{id}{name}")
 ```
 
 requests:
@@ -219,13 +219,13 @@ $ curl /000001?name=layertwo
 ## Multiple Routes
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 APP = API(name="app")
 
 @APP.get('/<id>', cors=True)
 @APP.get('/<id>/<int:number>', cors=True)
 def print_id(id, number=None, name=None):
-    return ('OK', 'plain/text', f"{id}-{name}-{number}")
+    return (StatusCode.OK, 'plain/text', f"{id}-{name}-{number}")
 ```
 requests:
 
@@ -248,7 +248,7 @@ $ curl /000001/1?name=layertwo
 Pass event and context to the handler function.
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 APP = API(name="app")
 
@@ -258,7 +258,7 @@ APP = API(name="app")
 def print_id(ctx, evt, id):
     print(ctx)
     print(evt)
-    return ('OK', 'plain/text', f"{id}")
+    return (StatusCode.OK, 'plain/text', f"{id}")
 ```
 
 # Automatic OpenAPI documentation
@@ -277,13 +277,13 @@ By default the APP (`aws_lambda_proxy.API`) is provided with three (3) routes:
 To be able to render full and precise API documentation, aws_lambda_proxy uses python type hint and annotations [link](https://www.python.org/dev/peps/pep-3107/).
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 APP = API(name="app")
 
 @APP.route('/test/<int:id>', methods=['GET'], cors=True)
 def print_id(id: int, num: float = 0.2) -> Tuple(str, str, str):
-    return ('OK', 'plain/text', id)
+    return (StatusCode.OK, 'plain/text', id)
 ```
 
 In the example above, our route `/test/<int:id>` define an input `id` to be a `INT`, while we also add this hint to the function `print_id` we also specify the type (and default) of the `num` option.
@@ -293,7 +293,7 @@ In the example above, our route `/test/<int:id>` define an input `id` to be a `I
 Note: When using path mapping other than `root` (`/`), `/` route won't be available.
 
 ```python
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode 
 
 api = API(name="api", debug=True)
 
@@ -310,12 +310,12 @@ def index():
             Hello world
         </body>
     </html>"""
-    return ("OK", "text/html", html)
+    return (StatusCode.OK, "text/html", html)
 
 
 @api.get("/yo", cors=True)
 def yo():
-    return ("OK", "text/plain", "YOOOOO")
+    return (StatusCode.OK, "text/plain", "YOOOOO")
 ```
 
 # Examples

--- a/aws_lambda_proxy/__init__.py
+++ b/aws_lambda_proxy/__init__.py
@@ -1,3 +1,5 @@
 """lambda-proxy: A simple AWS Lambda proxy to handle API Gateway request."""
 
+from http import HTTPStatus as StatusCode
+
 from .proxy import API

--- a/example/handler.py
+++ b/example/handler.py
@@ -4,73 +4,75 @@ import json
 import typing.io
 from typing import Dict, Tuple
 
-from aws_lambda_proxy import API
+from aws_lambda_proxy import API, StatusCode
 
 app = API(name="app", debug=True)
 
 
 @app.get("/", cors=True)
-def main() -> Tuple[str, str, str]:
+def main() -> Tuple[StatusCode, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", "Yo")
+    return (StatusCode.OK, "text/plain", "Yo")
 
 
 @app.get("/<regex([0-9]{2}-[a-zA-Z]{5}):regex1>", cors=True)
-def _re_one(regex1: str) -> Tuple[str, str, str]:
+def _re_one(regex1: str) -> Tuple[StatusCode, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", regex1)
+    return (StatusCode.OK, "text/plain", regex1)
 
 
 @app.get("/<regex([0-9]{1}-[a-zA-Z]{5}):regex2>", cors=True)
-def _re_two(regex2: str) -> Tuple[str, str, str]:
+def _re_two(regex2: str) -> Tuple[StatusCode, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", regex2)
+    return (StatusCode.OK, "text/plain", regex2)
 
 
 @app.post("/people", cors=True)
-def people_post(body) -> Tuple[str, str, str]:
+def people_post(body) -> Tuple[StatusCode, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", body)
+    return (StatusCode.OK, "text/plain", body)
 
 
 @app.get("/people", cors=True)
-def people_get() -> Tuple[str, str, str]:
+def people_get() -> Tuple[StatusCode, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", "Nope")
+    return (StatusCode.OK, "text/plain", "Nope")
 
 
 @app.get("/<string:user>", cors=True)
 @app.get("/<string:user>/<int:num>", cors=True)
-def double(user: str, num: int = 0) -> Tuple[str, str, str]:
+def double(user: str, num: int = 0) -> Tuple[StatusCode, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", f"{user}-{num}")
+    return (StatusCode.OK, "text/plain", f"{user}-{num}")
 
 
 @app.get("/kw/<string:user>", cors=True)
-def kw_method(user: str, **kwargs: Dict) -> Tuple[str, str, str]:
+def kw_method(user: str, **kwargs: Dict) -> Tuple[StatusCode, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", f"{user}")
+    return (StatusCode.OK, "text/plain", f"{user}")
 
 
 @app.get("/ctx/<string:user>", cors=True)
 @app.pass_context
 @app.pass_event
-def ctx_method(evt: Dict, ctx: Dict, user: str, num: int = 0) -> Tuple[str, str, str]:
+def ctx_method(
+    evt: Dict, ctx: Dict, user: str, num: int = 0
+) -> Tuple[StatusCode, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", f"{user}-{num}")
+    return (StatusCode.OK, "text/plain", f"{user}-{num}")
 
 
 @app.get("/json", cors=True)
-def json_handler() -> Tuple[str, str, str]:
+def json_handler() -> Tuple[StatusCode, str, str]:
     """Return JSON Object."""
-    return ("OK", "application/json", json.dumps({"app": "it works"}))
+    return (StatusCode.OK, "application/json", json.dumps({"app": "it works"}))
 
 
 @app.get("/binary", cors=True, payload_compression_method="gzip")
-def bin() -> Tuple[str, str, typing.io.BinaryIO]:
+def bin() -> Tuple[StatusCode, str, typing.io.BinaryIO]:
     """Return image."""
     with open("./rpix.png", "rb") as f:
-        return ("OK", "image/png", f.read())
+        return (StatusCode.OK, "image/png", f.read())
 
 
 @app.get(
@@ -79,7 +81,7 @@ def bin() -> Tuple[str, str, typing.io.BinaryIO]:
     payload_compression_method="gzip",
     binary_b64encode=True,
 )
-def b64bin() -> Tuple[str, str, typing.io.BinaryIO]:
+def b64bin() -> Tuple[StatusCode, str, typing.io.BinaryIO]:
     """Return base64 encoded image."""
     with open("./rpix.png", "rb") as f:
-        return ("OK", "image/png", f.read())
+        return (StatusCode.OK, "image/png", f.read())


### PR DESCRIPTION
HTTP status codes are strings. Python `http` stdlib has status codes, which is best to replace strings and the additional string checking that happens in the response method.