### PR TITLE
feat: add Response dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,31 +37,31 @@ open an issue.
 With GET request
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode
 
 APP = API(name="app")
 
 @APP.route('/test/tests/<id>', methods=['GET'], cors=True)
 def print_id(id):
-    return (StatusCode.OK, 'plain/text', id)
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=id)
 ```
 
 With POST request
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode
 
 APP = API(name="app")
 
 @APP.route('/test/tests/<id>', methods=['POST'], cors=True)
 def print_id(id, body):
-    return (StatusCode.OK, 'plain/text', id)
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=id)
 ```
 
 ## Binary body
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API
 
 APP = API(name="app")
 
@@ -93,11 +93,11 @@ example:
 ```python
 @APP.get("/app/<regex([a-z]+):regularuser>")
 def print_user(regularuser):
-    return (StatusCode.OK, 'plain/text', f"regular {regularuser}")
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=f"regular {regularuser}")
 
 @APP.get("/app/<regex([A-Z]+):capitaluser>")
 def print_user(capitaluser):
-    return (StatusCode.OK, 'plain/text', f"CAPITAL {capitaluser}")
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=f"CAPITAL {capitaluser}")
 ```
 
 #### Warning
@@ -107,11 +107,11 @@ when using **regex()** you must use different variable names or the route might 
 ```python
 @APP.get("/app/<regex([a-z]+):user>")
 def print_user(user):
-    return (StatusCode.OK, 'plain/text', f"regular {user}")
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=f"regular {user}")
 
 @APP.get("/app/<regex([A-Z]+):user>")
 def print_user(user):
-    return (StatusCode.OK, 'plain/text', f"CAPITAL {user}")
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=f"CAPITAL {user}")
 ```
 This app will work but the documentation will only show the second route because in `openapi.json`, route names will be `/app/{user}` for both routes.
 
@@ -133,12 +133,12 @@ This app will work but the documentation will only show the second route because
 Add a Cache Control header with a Time to Live (TTL) in seconds.
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode
 APP = API(app_name="app")
 
 @APP.get('/test/tests/<id>', cors=True, cache_control="public,max-age=3600")
 def print_id(id):
-   return (StatusCode.OK, 'plain/text', id)
+   return Response(status_code=StatusCode.OK, content_type='plain/text', body=id)
 ```
 
 Note: If function returns other then "OK", Cache-Control will be set to `no-cache`
@@ -148,14 +148,14 @@ Note: If function returns other then "OK", Cache-Control will be set to `no-cach
 When working with binary on API-Gateway we must return a base64 encoded string
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode
 
 APP = API(name="app")
 
 @APP.get('/test/tests/<filename>.jpg', cors=True, binary_b64encode=True)
 def print_id(filename):
     with open(f"{filename}.jpg", "rb") as f:
-        return (StatusCode.OK, 'image/jpeg', f.read())
+        return Response(status_code=StatusCode.OK, content_type='image/jpeg', body=f.read())
 ```
 
 ## Compression
@@ -163,7 +163,7 @@ def print_id(filename):
 Enable compression if "Accept-Encoding" if found in headers.
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode
 
 APP = API(name="app")
 
@@ -175,7 +175,7 @@ APP = API(name="app")
 )
 def print_id(filename):
     with open(f"{filename}.jpg", "rb") as f:
-       return (StatusCode.OK, 'image/jpeg', f.read())
+       return Response(status_code=StatusCode.OK, content_type='image/jpeg', body=f.read())
 ```
 
 ## Simple Auth token
@@ -187,13 +187,13 @@ Lambda-proxy provide a simple token validation system.
    http://myurl/test/tests/myid?access_token=blabla)
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode
 
 APP = API(name="app")
 
 @APP.get('/test/tests/<id>', cors=True, token=True)
 def print_id(id):
-    return (StatusCode.OK, 'plain/text', id)
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=id)
 ```
 
 ## URL schema and request parameters
@@ -201,13 +201,13 @@ def print_id(id):
 QueryString parameters are passed as function's options.
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode
 
 APP = API(name="app")
 
 @APP.get('/<id>', cors=True)
 def print_id(id, name=None):
-    return (StatusCode.OK, 'plain/text', f"{id}{name}")
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=f"{id}{name}")
 ```
 
 requests:
@@ -223,13 +223,13 @@ $ curl /000001?name=layertwo
 ## Multiple Routes
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode
 APP = API(name="app")
 
 @APP.get('/<id>', cors=True)
 @APP.get('/<id>/<int:number>', cors=True)
 def print_id(id, number=None, name=None):
-    return (StatusCode.OK, 'plain/text', f"{id}-{name}-{number}")
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=f"{id}-{name}-{number}")
 ```
 requests:
 
@@ -252,7 +252,7 @@ $ curl /000001/1?name=layertwo
 Pass event and context to the handler function.
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode
 
 APP = API(name="app")
 
@@ -262,7 +262,7 @@ APP = API(name="app")
 def print_id(ctx, evt, id):
     print(ctx)
     print(evt)
-    return (StatusCode.OK, 'plain/text', f"{id}")
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=f"{id}")
 ```
 
 # Automatic OpenAPI documentation
@@ -281,13 +281,13 @@ By default the APP (`aws_lambda_proxy.API`) is provided with three (3) routes:
 To be able to render full and precise API documentation, aws_lambda_proxy uses python type hint and annotations [link](https://www.python.org/dev/peps/pep-3107/).
 
 ```python
-from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy import API, Response, StatusCode 
 
 APP = API(name="app")
 
 @APP.route('/test/<int:id>', methods=['GET'], cors=True)
-def print_id(id: int, num: float = 0.2) -> Tuple[StatusCode, str, str]:
-    return (StatusCode.OK, 'plain/text', id)
+def print_id(id: int, num: float = 0.2) -> Response:
+    return Response(status_code=StatusCode.OK, content_type='plain/text', body=id)
 ```
 
 In the example above, our route `/test/<int:id>` define an input `id` to be a `INT`, while we also add this hint to the function `print_id` we also specify the type (and default) of the `num` option.
@@ -297,7 +297,7 @@ In the example above, our route `/test/<int:id>` define an input `id` to be a `I
 Note: When using path mapping other than `root` (`/`), `/` route won't be available.
 
 ```python
-from aws_lambda_proxy import API, StatusCode 
+from aws_lambda_proxy import API, Response, StatusCode 
 
 api = API(name="api", debug=True)
 
@@ -314,20 +314,20 @@ def index():
             Hello world
         </body>
     </html>"""
-    return (StatusCode.OK, "text/html", html)
+    return Response(status_code=StatusCode.OK, content_type="text/html", body=html)
 
 
 @api.get("/yo", cors=True)
 def yo():
-    return (StatusCode.OK, "text/plain", "YOOOOO")
+    return Response(status_code=StatusCode.OK, content_type="text/plain", body="YOOOOO")
 ```
 
 # Examples
 
--  https://github.com/aws-lambda-proxy/tree/main/example
+-  https://github.com/layertwo/aws-lambda-proxy/tree/main/example
 
 
-# Contribution & Devellopement
+# Contribution & Development
 
 Issues and pull requests are more than welcome.
 

--- a/aws_lambda_proxy/__init__.py
+++ b/aws_lambda_proxy/__init__.py
@@ -3,3 +3,4 @@
 from http import HTTPStatus as StatusCode
 
 from .proxy import API
+from .types import Response

--- a/aws_lambda_proxy/types.py
+++ b/aws_lambda_proxy/types.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import Union
+
+from aws_lambda_proxy import StatusCode
+
+
+@dataclass(frozen=True)
+class Response:
+    status_code: StatusCode
+    content_type: str
+    body: Union[str, bytes]

--- a/example/README.md
+++ b/example/README.md
@@ -15,6 +15,10 @@ $ python cli.py
 
 
 ```python
+from aws_lambda_proxy import API, Response, StatusCode 
+
+APP = API(name="api")
+
 @APP.route(
     "/<user>",
     methods=["GET"],
@@ -22,7 +26,7 @@ $ python cli.py
 )
 def main(user):
     """Return JSON Object."""
-    return ("OK", "text/plain", user)
+    return Response(status_code=StatusCode.OK, content_type="text/plain", body=user)
 ```
 
 ```
@@ -45,7 +49,7 @@ $ curl -i http://127.0.0.1:8000/
 @APP.route("/<string:user>@<int:num>", methods=["GET"], cors=True)
 def main(user, num=0):
     """Return JSON Object."""
-    return ("OK", "text/plain", f"{user}-{num}")
+    return Response(status_code=StatusCode.OK, content_type="text/plain", body=f"{user}-{num}")
 ```
 
 ```
@@ -68,7 +72,7 @@ $ curl -i http://127.0.0.1:8000/jqtrde@2
 )
 def json_handler():
     """Return JSON Object."""
-    return ("OK", "application/json", json.dumps({"app": "it works"}))
+    return Response(status_code=StatusCode.OK, content_type="application/json", body=json.dumps({"app": "it works"}))
 ```
 
 ```
@@ -97,10 +101,10 @@ $ curl -i http://127.0.0.1:8000/json
 def bin():
     """Return image."""
     with open("./rpix.png", "rb") as f:
-        return (
-            "OK",
-            "image/png",
-            f.read()
+        return Response(
+            status_code=StatusCode.OK,
+            content_type="image/png",
+            body=f.read()
         )
 ```
 
@@ -160,10 +164,10 @@ $ curl -v --compressed http://127.0.0.1:8000/binary > image.png
 def b64bin():
     """Return base64 encoded image."""
     with open("./rpix.png", "rb") as f:
-        return (
-            "OK",
-            "image/png",
-            f.read()
+        return Response(
+            status_code=StatusCode.OK,
+            content_type="image/png",
+            body=f.read()
         )
 ```
 

--- a/example/handler.py
+++ b/example/handler.py
@@ -1,78 +1,88 @@
 """app: handle requests."""
 
 import json
-import typing.io
-from typing import Dict, Tuple
+from typing import Dict
 
 from aws_lambda_proxy import API, StatusCode
+from aws_lambda_proxy.types import Response
 
 app = API(name="app", debug=True)
 
 
 @app.get("/", cors=True)
-def main() -> Tuple[StatusCode, str, str]:
+def main() -> Response:
     """Return JSON Object."""
-    return (StatusCode.OK, "text/plain", "Yo")
+    return Response(status_code=StatusCode.OK, content_type="text/plain", body="Yo")
 
 
 @app.get("/<regex([0-9]{2}-[a-zA-Z]{5}):regex1>", cors=True)
-def _re_one(regex1: str) -> Tuple[StatusCode, str, str]:
+def _re_one(regex1: str) -> Response:
     """Return JSON Object."""
-    return (StatusCode.OK, "text/plain", regex1)
+    return Response(status_code=StatusCode.OK, content_type="text/plain", body=regex1)
 
 
 @app.get("/<regex([0-9]{1}-[a-zA-Z]{5}):regex2>", cors=True)
-def _re_two(regex2: str) -> Tuple[StatusCode, str, str]:
+def _re_two(regex2: str) -> Response:
     """Return JSON Object."""
-    return (StatusCode.OK, "text/plain", regex2)
+    return Response(status_code=StatusCode.OK, content_type="text/plain", body=regex2)
 
 
 @app.post("/people", cors=True)
-def people_post(body) -> Tuple[StatusCode, str, str]:
+def people_post(body) -> Response:
     """Return JSON Object."""
-    return (StatusCode.OK, "text/plain", body)
+    return Response(status_code=StatusCode.OK, content_type="text/plain", body=body)
 
 
 @app.get("/people", cors=True)
-def people_get() -> Tuple[StatusCode, str, str]:
+def people_get() -> Response:
     """Return JSON Object."""
-    return (StatusCode.OK, "text/plain", "Nope")
+    return Response(status_code=StatusCode.OK, content_type="text/plain", body="Nope")
 
 
 @app.get("/<string:user>", cors=True)
 @app.get("/<string:user>/<int:num>", cors=True)
-def double(user: str, num: int = 0) -> Tuple[StatusCode, str, str]:
+def double(user: str, num: int = 0) -> Response:
     """Return JSON Object."""
-    return (StatusCode.OK, "text/plain", f"{user}-{num}")
+    return Response(
+        status_code=StatusCode.OK, content_type="text/plain", body=f"{user}-{num}"
+    )
 
 
 @app.get("/kw/<string:user>", cors=True)
-def kw_method(user: str, **kwargs: Dict) -> Tuple[StatusCode, str, str]:
+def kw_method(user: str, **kwargs: Dict) -> Response:
     """Return JSON Object."""
-    return (StatusCode.OK, "text/plain", f"{user}")
+    return Response(
+        status_code=StatusCode.OK, content_type="text/plain", body=f"{user}"
+    )
 
 
 @app.get("/ctx/<string:user>", cors=True)
 @app.pass_context
 @app.pass_event
-def ctx_method(
-    evt: Dict, ctx: Dict, user: str, num: int = 0
-) -> Tuple[StatusCode, str, str]:
+def ctx_method(evt: Dict, ctx: Dict, user: str, num: int = 0) -> Response:
     """Return JSON Object."""
-    return (StatusCode.OK, "text/plain", f"{user}-{num}")
+    return Response(
+        status_code=StatusCode.OK, content_type="text/plain", body=f"{user}-{num}"
+    )
 
 
 @app.get("/json", cors=True)
-def json_handler() -> Tuple[StatusCode, str, str]:
+def json_handler() -> Response:
     """Return JSON Object."""
-    return (StatusCode.OK, "application/json", json.dumps({"app": "it works"}))
+    return Response(
+        status_code=StatusCode.OK,
+        content_type="application/json",
+        body=json.dumps({"app": "it works"}),
+    )
 
 
 @app.get("/binary", cors=True, payload_compression_method="gzip")
-def bin() -> Tuple[StatusCode, str, typing.io.BinaryIO]:
+def bin() -> Response:
     """Return image."""
     with open("./rpix.png", "rb") as f:
-        return (StatusCode.OK, "image/png", f.read())
+        return Response(
+            status_code=StatusCode.OK, content_type="image/png", body=f.read()
+        )
 
 
 @app.get(
@@ -81,7 +91,9 @@ def bin() -> Tuple[StatusCode, str, typing.io.BinaryIO]:
     payload_compression_method="gzip",
     binary_b64encode=True,
 )
-def b64bin() -> Tuple[StatusCode, str, typing.io.BinaryIO]:
+def b64bin() -> Response:
     """Return base64 encoded image."""
     with open("./rpix.png", "rb") as f:
-        return (StatusCode.OK, "image/png", f.read())
+        return Response(
+            status_code=StatusCode.OK, content_type="image/png", body=f.read()
+        )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -4,12 +4,12 @@ import base64
 import json
 import os
 import zlib
-from typing import Dict, Tuple
+from typing import Dict
 from unittest.mock import Mock
 
 import pytest
 
-from aws_lambda_proxy import StatusCode, proxy
+from aws_lambda_proxy import Response, StatusCode, proxy
 
 json_api = os.path.join(os.path.dirname(__file__), "fixtures", "openapi.json")
 with open(json_api, "r") as f:
@@ -174,7 +174,9 @@ def test_API_addRoute():
 def test_proxy_API():
     """Add and parse route."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<string:user>/<name>", funct, methods=["GET"], cors=True)
 
     event = {
@@ -201,7 +203,9 @@ def test_proxy_API():
 def test_proxy_APIpath():
     """Add and parse route."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<string:user>/<name>", funct, methods=["GET"], cors=True)
 
     event = {
@@ -229,7 +233,9 @@ def test_proxy_APIpath():
 def test_proxy_APIpathProxy():
     """Add and parse route."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<string:user>/<name>", funct, methods=["GET"], cors=True)
 
     event = {
@@ -258,7 +264,9 @@ def test_proxy_APIpathProxy():
 def test_proxy_APIpathCustomDomain():
     """Add and parse route."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<string:user>/<name>", funct, methods=["GET"], cors=True)
 
     event = {
@@ -287,7 +295,9 @@ def test_proxy_APIpathCustomDomain():
 def test_ttl():
     """Add and parse route."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     with pytest.warns(DeprecationWarning):
         app._add_route(
             "/test/<string:user>/<name>",
@@ -298,7 +308,7 @@ def test_ttl():
         )
         funct_error = Mock(
             __name__="Mock",
-            return_value=(StatusCode.BAD_REQUEST, "text/plain", "heyyyy"),
+            return_value=Response(StatusCode.BAD_REQUEST, "text/plain", "heyyyy"),
         )
         app._add_route("/yo", funct_error, methods=["GET"], cors=True, ttl=3600)
 
@@ -336,7 +346,9 @@ def test_ttl():
 def test_cache_control():
     """Add and parse route."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route(
         "/test/<string:user>/<name>",
         funct,
@@ -345,7 +357,8 @@ def test_cache_control():
         cache_control="public,max-age=3600",
     )
     funct_error = Mock(
-        __name__="Mock", return_value=(StatusCode.BAD_REQUEST, "text/plain", "heyyyy")
+        __name__="Mock",
+        return_value=Response(StatusCode.BAD_REQUEST, "text/plain", "heyyyy"),
     )
     app._add_route(
         "/yo",
@@ -389,7 +402,9 @@ def test_cache_control():
 def test_querystringNull():
     """Add and parse route."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<user>", funct, methods=["GET"], cors=True)
 
     event = {
@@ -416,7 +431,9 @@ def test_querystringNull():
 def test_headersNull():
     """Add and parse route."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<user>", funct, methods=["GET"], cors=True)
 
     event = {
@@ -447,7 +464,9 @@ def test_API_encoding():
     body = b"thisisafakeencodedjpeg"
     b64body = base64.b64encode(body).decode()
 
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "image/jpeg", body))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "image/jpeg", body)
+    )
     app._add_route("/test/<user>.jpg", funct, methods=["GET"], cors=True)
 
     event = {
@@ -505,7 +524,9 @@ def test_API_compression():
     b64gzipbody = base64.b64encode(gzbody).decode()
 
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "image/jpeg", body))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "image/jpeg", body)
+    )
     app._add_route(
         "/test_compress/<user>.jpg",
         funct,
@@ -587,7 +608,9 @@ def test_API_compression():
 
     funct = Mock(
         __name__="Mock",
-        return_value=(StatusCode.OK, "application/json", json.dumps({"test": 0})),
+        return_value=Response(
+            StatusCode.OK, "application/json", json.dumps({"test": 0})
+        ),
     )
     # Should compress and encode to base64
     app._add_route(
@@ -655,7 +678,9 @@ def test_API_otherCompression():
     deflbody = deflate_compress.compress(body) + deflate_compress.flush()
 
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "image/jpeg", body))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "image/jpeg", body)
+    )
     app._add_route(
         "/test_deflate/<user>.jpg",
         funct,
@@ -719,7 +744,7 @@ def test_API_compression_invalid():
     app = proxy.API(name="test")
 
     def funct(user):
-        return (StatusCode.OK, "text/plain", "heyyyy")
+        return Response(StatusCode.OK, "text/plain", "heyyyy")
 
     entry = app._add_route(
         "/test/<user>",
@@ -748,7 +773,9 @@ def test_API_compression_invalid():
 def test_API_routeURL():
     """Should catch invalid route and parse valid args."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<user>", funct, methods=["GET"], cors=True)
 
     event = {
@@ -821,7 +848,9 @@ def test_API_routeURL():
     res = app(event, {})
     assert res == resp
 
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route(
         "/test/<string:v>/<uuid:uuid>/<int:z>/<float:x>.<ext>",
         funct,
@@ -865,7 +894,9 @@ def test_API_routeToken(monkeypatch):
     monkeypatch.setenv("TOKEN", "yo")
 
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<user>", funct, methods=["GET"], cors=True, token=True)
 
     event = {
@@ -990,7 +1021,9 @@ def test_API_functionError():
 def test_API_Post():
     """Should work as expected on POST request."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<user>", funct, methods=["GET", "POST"], cors=True)
 
     event = {
@@ -1069,7 +1102,7 @@ def test_API_ctx():
     @app.pass_event
     @app.pass_context
     def print_id(ctx, evt, id, params=None):
-        return (
+        return Response(
             StatusCode.OK,
             "application/json",
             {"ctx": ctx, "evt": evt, "id": id, "params": params},
@@ -1109,7 +1142,7 @@ def test_API_multipleRoute():
     @app.route("/<user>", methods=["GET"], cors=True)
     @app.route("/<user>@<int:num>", methods=["GET"], cors=True)
     def print_id(user, num=None, params=None):
-        return (
+        return Response(
             StatusCode.OK,
             "application/json",
             json.dumps({"user": user, "num": num, "params": params}),
@@ -1161,24 +1194,24 @@ def test_API_doc():
     app = proxy.API(name="test")
 
     @app.route("/test", methods=["POST"])
-    def _post(body: str) -> Tuple[StatusCode, str, str]:
+    def _post(body: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "Yo")
+        return Response(StatusCode.OK, "text/plain", "Yo")
 
     @app.route("/<user>", methods=["GET"], tag=["users"], description="a route")
-    def _user(user: str) -> Tuple[StatusCode, str, str]:
+    def _user(user: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "Yo")
+        return Response(StatusCode.OK, "text/plain", "Yo")
 
     @app.route("/<int:num>", methods=["GET"], token=True)
-    def _num(num: int) -> Tuple[StatusCode, str, str]:
+    def _num(num: int) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     @app.route("/<user>/<int:num>", methods=["GET"])
-    def _userandnum(user: str, num: int) -> Tuple[StatusCode, str, str]:
+    def _userandnum(user: str, num: int) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     @app.route("/<user>/<float:num>", methods=["GET"])
     def _options(
@@ -1188,16 +1221,16 @@ def test_API_doc():
         opt2: int = 2,
         opt3: float = 2.0,
         **kwargs,
-    ) -> Tuple[StatusCode, str, str]:
+    ) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     @app.route("/<user>/<num>", methods=["GET"])
     @app.pass_context
     @app.pass_event
-    def _ctx(evt: Dict, ctx: Dict, user: str, num: int) -> Tuple[StatusCode, str, str]:
+    def _ctx(evt: Dict, ctx: Dict, user: str, num: int) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     event = {
         "path": "/openapi.json",
@@ -1262,24 +1295,24 @@ def test_API_doc_apigw():
     app = proxy.API(name="test")
 
     @app.route("/test", methods=["POST"])
-    def _post(body: str) -> Tuple[StatusCode, str, str]:
+    def _post(body: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "Yo")
+        return Response(StatusCode.OK, "text/plain", "Yo")
 
     @app.route("/<user>", methods=["GET"], tag=["users"], description="a route")
-    def _user(user: str) -> Tuple[StatusCode, str, str]:
+    def _user(user: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "Yo")
+        return Response(StatusCode.OK, "text/plain", "Yo")
 
     @app.route("/<int:num>", methods=["GET"], token=True)
-    def _num(num: int) -> Tuple[StatusCode, str, str]:
+    def _num(num: int) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     @app.route("/<user>/<int:num>", methods=["GET"])
-    def _userandnum(user: str, num: int) -> Tuple[StatusCode, str, str]:
+    def _userandnum(user: str, num: int) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     @app.route("/<user>/<float:num>", methods=["GET"])
     def _options(
@@ -1289,16 +1322,16 @@ def test_API_doc_apigw():
         opt2: int = 2,
         opt3: float = 2.0,
         **kwargs,
-    ) -> Tuple[StatusCode, str, str]:
+    ) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     @app.route("/<user>/<num>", methods=["GET"])
     @app.pass_context
     @app.pass_event
-    def _ctx(evt: Dict, ctx: Dict, user: str, num: int) -> Tuple[StatusCode, str, str]:
+    def _ctx(evt: Dict, ctx: Dict, user: str, num: int) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     event = {
         "path": "/openapi.json",
@@ -1348,24 +1381,24 @@ def test_API_docCustomDomain():
     app = proxy.API(name="test")
 
     @app.route("/test", methods=["POST"])
-    def _post(body: str) -> Tuple[StatusCode, str, str]:
+    def _post(body: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "Yo")
+        return Response(StatusCode.OK, "text/plain", "Yo")
 
     @app.route("/<user>", methods=["GET"], tag=["users"], description="a route")
-    def _user(user: str) -> Tuple[StatusCode, str, str]:
+    def _user(user: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "Yo")
+        return Response(StatusCode.OK, "text/plain", "Yo")
 
     @app.route("/<int:num>", methods=["GET"], token=True)
-    def _num(num: int) -> Tuple[StatusCode, str, str]:
+    def _num(num: int) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     @app.route("/<user>/<int:num>", methods=["GET"])
-    def _userandnum(user: str, num: int) -> Tuple[StatusCode, str, str]:
+    def _userandnum(user: str, num: int) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     @app.route("/<user>/<float:num>", methods=["GET"])
     def _options(
@@ -1375,16 +1408,16 @@ def test_API_docCustomDomain():
         opt2: int = 2,
         opt3: float = 2.0,
         **kwargs,
-    ) -> Tuple[StatusCode, str, str]:
+    ) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     @app.route("/<user>/<num>", methods=["GET"])
     @app.pass_context
     @app.pass_event
-    def _ctx(evt: Dict, ctx: Dict, user: str, num: int) -> Tuple[StatusCode, str, str]:
+    def _ctx(evt: Dict, ctx: Dict, user: str, num: int) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", "yo")
+        return Response(StatusCode.OK, "text/plain", "yo")
 
     event = {
         "resource": "/{proxy+}",
@@ -1416,10 +1449,10 @@ def test_routeRegex():
     """Add and parse route."""
     app = proxy.API(name="test")
     funct_one = Mock(
-        __name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy")
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
     )
     funct_two = Mock(
-        __name__="Mock", return_value=(StatusCode.OK, "text/plain", "yooooo")
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "yooooo")
     )
     app._add_route(
         "/test/<regex([0-9]{4}):number>/<regex([a-z]{3}):name>",
@@ -1481,7 +1514,9 @@ def test_routeRegex():
 def test_routeRegexFailing():
     """Add and parse route."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "yooooo"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "yooooo")
+    )
     app._add_route(
         r"/test/<regex(user(\d+)?):user>/<sport>",
         funct,
@@ -1623,7 +1658,9 @@ def testApigwPath():
 def testApigwHostUrl():
     """Test url property."""
     app = proxy.API(name="test")
-    funct = Mock(__name__="Mock", return_value=(StatusCode.OK, "text/plain", "heyyyy"))
+    funct = Mock(
+        __name__="Mock", return_value=Response(StatusCode.OK, "text/plain", "heyyyy")
+    )
     app._add_route("/test/<string:user>/<name>", funct, methods=["GET"], cors=True)
 
     # resource "/", no apigwg, noproxy, no path mapping
@@ -1717,39 +1754,39 @@ def test_API_simpleRoute():
     app = proxy.API(name="test")
 
     @app.post("/test")
-    def _post(body: str) -> Tuple[StatusCode, str, str]:
+    def _post(body: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", body)
+        return Response(StatusCode.OK, "text/plain", body)
 
     @app.put("/<user>")
-    def _put(user: str, body: str) -> Tuple[StatusCode, str, str]:
+    def _put(user: str, body: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", body)
+        return Response(StatusCode.OK, "text/plain", body)
 
     @app.patch("/<user>")
-    def _patch(user: str, body: str) -> Tuple[StatusCode, str, str]:
+    def _patch(user: str, body: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", body)
+        return Response(StatusCode.OK, "text/plain", body)
 
     @app.delete("/<user>")
-    def _delete(user: str) -> Tuple[StatusCode, str, str]:
+    def _delete(user: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", user)
+        return Response(StatusCode.OK, "text/plain", user)
 
     @app.options("/<user>")
-    def _options(user: str) -> Tuple[StatusCode, str, str]:
+    def _options(user: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", user)
+        return Response(StatusCode.OK, "text/plain", user)
 
     @app.head("/<user>")
-    def _head(user: str) -> Tuple[StatusCode, str, str]:
+    def _head(user: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", user)
+        return Response(StatusCode.OK, "text/plain", user)
 
     @app.get("/<user>", tag=["users"], description="a route", cors=True)
-    def _user(user: str) -> Tuple[StatusCode, str, str]:
+    def _user(user: str) -> Response:
         """Return something."""
-        return (StatusCode.OK, "text/plain", user)
+        return Response(StatusCode.OK, "text/plain", user)
 
     event = {
         "path": "/remotepixel",


### PR DESCRIPTION
Add a `Response` dataclass rather than using a tuple, this allows for future field expansion in the response (such as headers).